### PR TITLE
Confined pageId: pageId should be able to be overridden on a per-page basis

### DIFF
--- a/src/Heex/Heex.jsx
+++ b/src/Heex/Heex.jsx
@@ -4,7 +4,7 @@ import { HeexContextProvider } from "./context";
 import { fetchAnonymousToken } from "./utils/query";
 import { validate, HeexOptionsCenter } from "./utils";
 
-export const Heex = ({ options }) => {
+export const Heex = ({ options, pageId }) => {
     if (typeof window !== "undefined") {
         validate.options(options);
         HeexOptionsCenter.assignHeexOptions(options);
@@ -18,7 +18,7 @@ export const Heex = ({ options }) => {
 
     return (
         <div className="heex-container">
-            <HeexContextProvider>
+            <HeexContextProvider pageId={pageId}>
                 <CommentEditor isTopLevel />
                 <CommentMeta />
                 <CommentList />

--- a/src/Heex/components/CommentEditor/CommentEditor.jsx
+++ b/src/Heex/components/CommentEditor/CommentEditor.jsx
@@ -12,7 +12,7 @@ export const CommentEditor = (props) => {
 
     const [loading, setLoading] = useState(false);
     const submitButtonRef = useRef();
-    const { refreshCommentsWithLimit, refreshThread } = useHeexContext();
+    const { refreshCommentsWithLimit, refreshThread, state } = useHeexContext();
 
     const editorId = reply?.objectId || thread?.objectId || "Heex";
 
@@ -38,7 +38,7 @@ export const CommentEditor = (props) => {
         const result = await query.createComment({
             username,
             email,
-            pageId: window.location.pathname,
+            pageId: state.pageId,
             comment: commentContent,
             tid: thread?.objectId,
             rid: reply?.objectId,

--- a/src/Heex/components/CommentList/CommentList.jsx
+++ b/src/Heex/components/CommentList/CommentList.jsx
@@ -21,8 +21,8 @@ export const CommentList = () => {
         // * leancloud can get count and comments in one query,
         // * but I am not sure whether other database can do that too
         Promise.all([
-            query.getCommentCount(),
-            query.getComments({ limit: 25 }),
+            query.getCommentCount({ pageId: state.pageId }),
+            query.getComments({ limit: 25, pageId: state.pageId }),
         ]).then((res) => {
             const [count, comments] = res;
 
@@ -43,7 +43,11 @@ export const CommentList = () => {
 
     const handleLoadMore = useMemoizedFn(() => {
         query
-            .getComments({ limit: 25, offset: state.commentCount })
+            .getComments({
+                limit: 25,
+                offset: state.commentCount,
+                pageId: state.pageId,
+            })
             .then((comments) => {
                 dispatch({
                     type: ACTION.APPEND_COMMENTS,

--- a/src/Heex/context/index.js
+++ b/src/Heex/context/index.js
@@ -15,13 +15,13 @@ const initialState = {
 };
 
 const HeexContextProvider = (props) => {
-    const { children } = props;
+    const { children, pageId } = props;
 
-    const [state, dispatch] = useReducer(reducer, { ...initialState });
+    const [state, dispatch] = useReducer(reducer, { ...initialState, pageId });
 
     const refreshCommentsWithLimit = useMemoizedFn(async () => {
         // limit is the current number of comments, no need to fetch all
-        const comments = await getComments({ limit: 25 });
+        const comments = await getComments({ limit: 25, pageId: state.pageId });
         if (comments !== undefined) {
             dispatch({
                 type: ACTION.SET_COMMENTS,

--- a/src/Heex/utils/query.js
+++ b/src/Heex/utils/query.js
@@ -21,6 +21,7 @@ export const createComment = async function (payload) {
     try {
         const response = await heexHttpPost(`${apiBaseUrl}/comment`, {
             ...payload,
+            pageId: payload.pageId || window.location.pathname,
             clientName,
             clientId,
         });
@@ -32,13 +33,13 @@ export const createComment = async function (payload) {
     }
 };
 
-export const getCommentCount = async function () {
+export const getCommentCount = async function ({ pageId }) {
     const { clientId, apiBaseUrl } = window.HeexOptions;
 
     try {
-        const pageId = window.location.pathname;
+        const _pageId = pageId || window.location.pathname;
         const response = await fetch(
-            `${apiBaseUrl}/comment/count?pageId=${pageId}&clientId=${clientId}`
+            `${apiBaseUrl}/comment/count?pageId=${_pageId}&clientId=${clientId}`
         );
         const json = await response.json();
         return json.data.count;
@@ -50,11 +51,11 @@ export const getCommentCount = async function () {
 
 export const getComments = async function (params) {
     try {
-        const pageId = window.location.pathname;
+        const { limit, offset, pageId } = params || {};
+        const _pageId = pageId || window.location.pathname;
         const { apiBaseUrl, clientId } = window.HeexOptions;
-        const { limit, offset } = params || {};
         const urlSearchParams = new URLSearchParams({
-            pageId,
+            pageId: _pageId,
             clientId,
         });
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import { Heex } from "./Heex";
 const defaultOptions = {
     rootElement: "#heex",
     auth: {
-        use: "anonymous",
+        use: "anonymous", // 'heex', 'host', 'anonymous'
     },
 };
 


### PR DESCRIPTION
## use case:

Heex ( vanilla javascript) itself  is used when you have a blog,  a product page. There is only one Heex instance used in an individual page. For now, Heex sets pageId to be window.location.pathname by default.

However, let's image another scenario. When you have multiple `Item` in a page, each of which is a post/blog/news. Each of the items needs a comment section. Then, the user can have multiple Heex instances open in the same time. Then, it would be unreasonable if each  Heex instance shares the same pageId (window.location.pathname). Basically, I build this feature for TickerTick.com

So, we need to a mechanism to override this default pageId value . And each Heex instance can have its own unique pageId.

By the way, pageId is just an identifier for the Heex instance. It could be `contentId`, or `instanceId`. It's just an ID.

This PR is actually for @Heex/react component, since I assume Heex is only one instance per page, while it could be multiple instances if you are using React/Vue/solidjs etc to build your frontend web app.